### PR TITLE
Move Rijkswaterstaat and move BAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Dutch public sector.
     * [Dienst ICT Uitvoering](https://github.com/Dictu)
     * [GIS Competence Centre](https://github.com/MinELenI)
 * [Ministerie van Infrastructuur en Milieu](https://github.com/MinIenM)
+    * [Rijkswaterstaat 2](https://github.com/RWS-NL)
 * Ministerie van Justitie en Veiligheid
     * [Nationaal Cyber Security Centrum (NCSC)](https://github.com/NCSC-NL)
 * [Ministerie van Volksgezondheid, Welzijn en Sport](https://github.com/minvws)
@@ -88,12 +89,9 @@ Partnerships between municipalities:
 
 *Organisations in field of managing the public space*
 
-* Rijkswaterstaat
-    * [Rijkswaterstaat 1](https://github.com/Rijkswaterstaat)
-    * [Rijkswaterstaat 2](https://github.com/RWS-NL)
-* [Landelijke voorziening BAG](https://github.com/lvbag)
 * [Kadaster](https://github.com/kadaster)
     * [Labs](https://github.com/kadaster-labs)
+    * [Landelijke voorziening BAG](https://github.com/lvbag)
     * [PDOK](https://github.com/pdok) (Publieke Diensten Op de Kaart)
 
 ### Data and statistics


### PR DESCRIPTION
Ministries have like 30 agencies and each may have some projects or initiatives that have their own organisation on Github. Ordering like that, the Ministries will get organisations like Rijkswarterstaat, Logius, but also data.overheid.nl  (Which is created by KOOP, which is part of MinBZK).

Then there are 'Independent Administrative Bodies'  (ZBO) like Kadaster and KvK, 160 of them. Those can be ordered by theme perhaps?